### PR TITLE
Feature: Basic Testing and Upgrade to Predis v1.0.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# Composer dependencies
+/vendor/
+/composer.lock
+
+# Auto-generated documentation directory (phpDocumentor)
+/docs/
+
+# Auto-generated code coverage report
+/report/
+/coverage.xml

--- a/composer.json
+++ b/composer.json
@@ -23,5 +23,8 @@
     },
     "autoload": {
         "psr-0": { "OneMightyRoar\\PredisToolkit\\": "src/" }
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^4.7"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "predis/predis": "0.8.3"
+        "predis/predis": "^1.0"
     },
     "autoload": {
         "psr-0": { "OneMightyRoar\\PredisToolkit\\": "src/" }

--- a/composer.json
+++ b/composer.json
@@ -26,5 +26,8 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^4.7"
+    },
+    "autoload-dev": {
+        "psr-4": { "OneMightyRoar\\PredisToolkit\\Test\\": "tests/" }
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false"
+         syntaxCheck="false"
+         bootstrap="tests/bootstrap.php"
+>
+    <testsuites>
+        <testsuite name="Client Unit Tests">
+            <directory>./tests/</directory>
+            <groups>
+                <exclude>
+                    <group>NetworkIntegration</group>
+                </exclude>
+            </groups>
+        </testsuite>
+        <testsuite name="Full Test Suite">
+            <directory>./tests/</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist>
+            <directory>./src</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -12,15 +12,7 @@
          bootstrap="tests/bootstrap.php"
 >
     <testsuites>
-        <testsuite name="Client Unit Tests">
-            <directory>./tests/</directory>
-            <groups>
-                <exclude>
-                    <group>NetworkIntegration</group>
-                </exclude>
-            </groups>
-        </testsuite>
-        <testsuite name="Full Test Suite">
+        <testsuite name="Test Suite">
             <directory>./tests/</directory>
         </testsuite>
     </testsuites>

--- a/tests/OneMightyRoar/PredisToolkit/Tests/ClientTest.php
+++ b/tests/OneMightyRoar/PredisToolkit/Tests/ClientTest.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * Predis-Toolkit
+ *
+ * Additional classes and functionality to extend Predis
+ *
+ * @copyright 2013 One Mighty Roar
+ * @link http://onemightyroar.com
+ */
+
+namespace OneMightyRoar\PredisToolkit\Test;
+
+use OneMightyRoar\PredisToolkit\Client;
+use PHPUnit_Framework_TestCase;
+
+/**
+ * Tests the {@link Client} class.
+ */
+class ClientTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * Properties
+     */
+
+    /**
+     * The {@link Client} to test.
+     *
+     * @type Client
+     */
+    private $client;
+
+    /**
+     * Methods
+     */
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->client = new Client($this->getMockConnection());
+    }
+
+    private function getMockConnection()
+    {
+        $mock_connection = $this->getMock('Predis\Connection\ConnectionInterface');
+
+        return $mock_connection;
+    }
+
+    public function testSupportedCommands()
+    {
+        $profile = $this->client->getProfile();
+
+        $commands = $profile->getSupportedCommands();
+
+        $key = 'COMMAND:ARG';
+
+        foreach ($commands as $cmd => $cls) {
+            $command = null;
+
+            if ('info' === $cmd) {
+                $this->client->getConnection()->expects($this->at(0))->method('executeCommand')
+                    ->with($this->callback(function ($com) use (&$command) {
+                        $command = $com;
+                        return true;
+                    }))
+                    ->will($this->returnValue('INFO'));
+
+                $this->client->$cmd();
+                $this->assertInstanceOf($cls, $command);
+            } elseif ('quit' === $cmd) {
+                $this->client->getConnection()->expects($this->at(0))->method('disconnect')->will($this->returnValue(null));
+
+                $val = $this->client->$cmd($key);
+                $this->assertNull($val);
+            } else {
+                $this->client->getConnection()->expects($this->at(0))->method('executeCommand')
+                    ->with($this->callback(function ($com) use (&$command) {
+                        $command = $com;
+                        return true;
+                    }));
+
+                $this->client->$cmd($key, []);
+                $this->assertInstanceOf($cls, $command);
+            }
+        }
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -10,4 +10,3 @@
 
 // Load our autoloader, and add our Test class namespace
 $autoloader = require(__DIR__ . '/../vendor/autoload.php');
-$autoloader->add('OneMightyRoar\PredisToolki\Tests', __DIR__);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * Predis-Toolkit
+ *
+ * Additional classes and functionality to extend Predis
+ *
+ * @copyright 2015 One Mighty Roar
+ * @link http://onemightyroar.com
+ */
+
+// Load our autoloader, and add our Test class namespace
+$autoloader = require(__DIR__ . '/../vendor/autoload.php');
+$autoloader->add('OneMightyRoar\PredisToolki\Tests', __DIR__);


### PR DESCRIPTION
In order to test that an upgrade to `Predis` v1.0 wouldn't break anything, I'm submitting this **basic** PR. 

I looked at this libraries touchpoints with `Predis` and it the scenario that needed testing was the passing through of redis commands as part of the magic caller that gets overwritten in [PredisToolkit\Client.php](https://github.com/onemightyroar/predis-toolkit/blob/d09e77ead5177362b47771daa699f5537d3fb1ff/src/OneMightyRoar/PredisToolkit/Client.php#L91-L100)

I wrote and tested this with Predis 0.8.3, then upgraded to Predis v1.0 and the testing outcomes the same with both (this repo doesn't have travis, so there's no build that'll reproduce).

If anyone things of any tests that they'd like to see, then let me know. Otherwise, I tried to keep this as lightweight as possible (of course, there's plenty more stuff that should get tested, but that's outside the responsibility of upgrading the `Predis` library).
